### PR TITLE
chore(goreleaser): remove deprecated config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 .idea
 
 dist/
+.env

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -11,12 +11,13 @@ builds:
       - windows
       - darwin
 archives:
-  - replacements:
-      darwin: Darwin
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
+  - name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Addresses issue https://github.com/peppys/crib/issues/7 - `goreleaser` fails due to a [deprecation](https://goreleaser.com/deprecations/#archivesreplacements) in the most recent version.
