### PR TITLE
feature(goreleaser): explicitly specify target build architectures, and include arm 32-bit.

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,11 @@ builds:
       - linux
       - windows
       - darwin
+    goarch:
+      - arm
+      - arm64
+      - amd64
+      - "386"
 archives:
   - name_template: >-
       {{- .ProjectName }}_


### PR DESCRIPTION
Addresses issue https://github.com/peppys/crib/issues/8 

Updates the `goreleaser` config to explicitly specify target build architectures, and include arm 32-bit.